### PR TITLE
Add pagination to board and inbox

### DIFF
--- a/askme/askme/urls.py
+++ b/askme/askme/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     path('register/', user_views.register, name='register'),
     path('login/', auth_views.LoginView.as_view(template_name='users/login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(template_name='users/logout.html'), name='logout'),
-    path('inbox/', core_views.Inbox.as_view(), name='inbox'),
+    path('inbox/', core_views.inbox, name='inbox'),
     path('inbox/question/<int:question_id>', question_views.answer_question, name='answer_question'),
     re_path(r'^board/(?P<username>[\w.-_]+)/$', core_views.board, name='board'),
     re_path(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', user_views.activate_account, name='activate')

--- a/askme/core/templates/core/board.html
+++ b/askme/core/templates/core/board.html
@@ -7,10 +7,11 @@
     <div class=".row">
         {% include "questions/post_question.html" %}
     </div>
-    {% for question in questions %}
+    {% for question in questions_page %}
     <div class=".row">
         {% include "questions/answered_question.html" %}
     </div>
     {% endfor %}
+    {% include "core/pagination.html" %}
 </div>
 {% endblock %}

--- a/askme/core/templates/core/inbox.html
+++ b/askme/core/templates/core/inbox.html
@@ -4,10 +4,11 @@
 {% endblock %}
 {% block content %}
 <div class="container">
-    {% for question in questions %}
+    {% for question in questions_page %}
     <div class=".row">
         {% include "questions/unanswered_question.html" %}
     </div>
     {% endfor %}
+    {% include "core/pagination.html" %}
 </div>
 {% endblock %}

--- a/askme/core/templates/core/pagination.html
+++ b/askme/core/templates/core/pagination.html
@@ -1,0 +1,43 @@
+<ul class="pagination justify-content-center">
+    {% if questions_page.has_previous %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{questions_page.previous_page_number}}" aria-label="Previous">
+                <span>&laquo; Previous</span>
+            </a>
+        </li>
+    {% else %}
+        <li class="page-item disabled">
+            <a class="page-link" href="#">
+                <span>&laquo; Previous</span>
+            </a>
+        </li>
+    {% endif %}
+    {% for page_num in questions_page.paginator.page_range %}
+        {% if questions_page.number == page_num %}
+            <li class="page-item active">
+                <a class="page-link">
+                    <span>{{ page_num }}</span><!--span class="sr-only">(current)</span!-->
+                </a>
+            </li>
+        {% else %}
+            <li class="page-item">
+                <a class="page-link" href="?page={{ page_num }}">
+                    <span>{{ page_num }}</span>
+                </a>
+            </li>
+        {% endif %}
+    {% endfor %}
+    {% if questions_page.has_next %}
+        <li class="page-item">
+            <a class="page-link" href="?page={{questions_page.next_page_number}}" aria-label="Next">
+                <span>Next &raquo</span>
+            </a>
+        </li>
+    {% else %}
+        <li class="page-item disabled">
+            <a class="page-link" href="#">
+                <span>Next &raquo</span>
+            </a>
+        </li>
+    {% endif %}
+</ul>

--- a/askme/core/views.py
+++ b/askme/core/views.py
@@ -1,8 +1,7 @@
 from django.contrib import messages
+from django.core.paginator import Paginator
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
-from django.views.generic import View
-from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required
 
 from questions.forms import PostQuestionForm
@@ -40,19 +39,21 @@ def board(request, username):
         return redirect('/login/')
     form = PostQuestionForm()
     questions = profile.user.get_public_questions()
+    paginator = Paginator(questions, 5)
+    questions_page = paginator.get_page(request.GET.get('page'))
     return render(request, 'core/board.html', {
         'question_max_length': 512,
         'profile': profile,
-        'questions': questions,
+        'questions_page': questions_page,
         'form': form
     })
 
 
-class Inbox(View):
-    @method_decorator(login_required)
-    def get(self, request):
-        unanswered_questions = request.user.get_unanswered_questions()
-        return render(request, 'core/inbox.html', {
-            'questions': unanswered_questions
-        })
-
+@login_required
+def inbox(request):
+    unanswered_questions = request.user.get_unanswered_questions()
+    paginator = Paginator(unanswered_questions, 5)
+    questions_page = paginator.get_page(request.GET.get('page'))
+    return render(request, 'core/inbox.html', {
+        'questions_page': questions_page
+    })

--- a/askme/tests/test_core/test_views.py
+++ b/askme/tests/test_core/test_views.py
@@ -50,7 +50,7 @@ class TestBoardView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(Question.objects.all()), 0)
 
-    def test_when_user2_has_2_public_questions_then_render_tempalte_with_2_questions(self):
+    def test_when_user2_has_2_public_questions_then_render_template_with_2_questions(self):
         self.client.force_login(self.user1)
         q1 = Question.objects.create(asked_by=self.user1, asked_to=self.user2, content='question 1 ?')
         q2 = Question.objects.create(asked_by=self.user1, asked_to=self.user2, content='question 2 ?')
@@ -58,10 +58,10 @@ class TestBoardView(TestCase):
         Answer.objects.create(question=q2, content='no')
         response = self.client.get(reverse('board', kwargs={'username': 'user2'}))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context['questions']), 2)
-        self.assertQuerysetEqual(response.context['questions'], [repr(q1), repr(q2)], ordered=False)
+        self.assertEqual(len(response.context['questions_page'].object_list), 2)
+        self.assertQuerysetEqual(response.context['questions_page'].object_list, [repr(q1), repr(q2)], ordered=False)
 
-    def test_when_user2_has_1_public_and_1_hidden_question_then_render_tempalte_with_1_only_public_question(self):
+    def test_when_user2_has_1_public_and_1_hidden_question_then_render_template_with_1_only_public_question(self):
         self.client.force_login(self.user1)
         q1 = Question.objects.create(asked_by=self.user1, asked_to=self.user2, content='question 1 ?')
         q2 = Question.objects.create(asked_by=self.user1, asked_to=self.user2, content='question 2 ?', hidden=True)
@@ -69,7 +69,94 @@ class TestBoardView(TestCase):
         Answer.objects.create(question=q2, content='no')
         response = self.client.get(reverse('board', kwargs={'username': 'user2'}))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.context['questions']), 1)
-        self.assertQuerysetEqual(response.context['questions'], [repr(q1)], ordered=False)
+        self.assertEqual(len(response.context['questions_page'].object_list), 1)
+        self.assertQuerysetEqual(response.context['questions_page'].object_list, [repr(q1)], ordered=False)
+
+    def test_pagination(self):
+        self.client.force_login(self.user1)
+        question_list = []
+        for i in range(1, 21):
+            q = Question.objects.create(asked_by=self.user1, asked_to=self.user2, content=f'question {i}?')
+            question_list.append(q)
+            Answer.objects.create(question=q, content=f'answer {i}')
+
+        question_list.reverse()
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[:5])
+
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}) + '?page=2')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[5:10])
+
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}) + '?page=3')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[10:15])
+
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}) + '?page=4')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[15:20])
+
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}) + '?page=123')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}) + '?page=-123')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+
+        response = self.client.get(reverse('board', kwargs={'username': 'user2'}) + '?page=asd')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
 
 
+class TestInboxView(TestCase):
+    def setUp(self):
+        self.user1 = User(email='user1@mail.com', username='user1', password='asdasdasd', is_active=True)
+        self.user1.save()
+        self.user2 = User(email='user2@mail.com', username='user2', password='asdasdasd', is_active=True)
+        self.user2.save()
+
+    def test_pagination(self):
+        self.client.force_login(self.user2)
+        question_list = []
+        for i in range(1, 21):
+            q = Question.objects.create(asked_by=self.user1, asked_to=self.user2, content=f'question {i}?')
+            question_list.append(q)
+
+        question_list.reverse()
+        response = self.client.get(reverse('inbox'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[:5])
+
+        response = self.client.get(reverse('inbox') + '?page=2')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[5:10])
+
+        response = self.client.get(reverse('inbox') + '?page=3')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[10:15])
+
+        response = self.client.get(reverse('inbox') + '?page=4')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+        self.assertEqual(response.context['questions_page'].object_list, question_list[15:20])
+
+        response = self.client.get(reverse('inbox') + '?page=123')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+
+        response = self.client.get(reverse('inbox') + '?page=-123')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)
+
+        response = self.client.get(reverse('inbox') + '?page=asd')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['questions_page'].object_list), 5)


### PR DESCRIPTION
## Added pagination logic for _inbox_ and _board_ views.

 - change inbox view to be a function views since it's very small
 - added pagination.html, used by both _board_ and _inbox_ views
 - added testing for pagination logic